### PR TITLE
[v0.5.8] Release

### DIFF
--- a/zerohertzLib/api/koreainvestment.py
+++ b/zerohertzLib/api/koreainvestment.py
@@ -338,6 +338,11 @@ class KoreaInvestment:
                 params["FID_INPUT_DATE_2"] = data["output2"][-1]["stck_bsop_date"]
                 response = requests.get(url, headers=headers, params=params, timeout=10)
                 data_ = response.json()
+                if (
+                    data["output2"][-1]["stck_bsop_date"]
+                    == data_["output2"][-1]["stck_bsop_date"]
+                ):
+                    break
                 data["output2"] += data_["output2"][1:]
                 time.sleep(0.02)
         return data
@@ -393,6 +398,8 @@ class KoreaInvestment:
                 params["BYMD"] = data["output2"][-1]["xymd"]
                 response = requests.get(url, headers=headers, params=params, timeout=10)
                 data_ = response.json()
+                if data["output2"][-1]["xymd"] == data_["output2"][-1]["xymd"]:
+                    break
                 data["output2"] += data_["output2"][1:]
                 time.sleep(0.02)
         return data

--- a/zerohertzLib/plot/plot.py
+++ b/zerohertzLib/plot/plot.py
@@ -112,7 +112,7 @@ def candle(
     dpi: Optional[int] = 300,
     save: Optional[bool] = True,
     signals: Optional[Dict[str, Any]] = None,
-    threshold: Optional[int] = 1,
+    threshold: Optional[Union[int, Tuple[int]]] = 1,
 ) -> str:
     """OHLCV (Open, High, Low, Close, Volume) data에 따른 candle chart
 
@@ -123,7 +123,7 @@ def candle(
         dpi: (``Optional[int]``): Graph 저장 시 DPI (Dots Per Inch)
         save (``Optional[bool]``): Graph 저장 여부
         signals (``Optional[Dict[str, Any]]``): 추가적으로 plot할 data
-        threshold (``Optional[int]``): 매수, 매도를 결정할 ``signals`` 경계값
+        threshold (``Optional[Union[int, Tuple[int]]]``): 매수, 매도를 결정할 ``signals`` 경계값
 
     Returns:
         ``str``: 저장된 graph의 절대 경로
@@ -143,6 +143,10 @@ def candle(
             :align: center
             :width: 800px
     """
+    if not isinstance(threshold, int):
+        threshold_sell, threshold_buy = threshold
+    else:
+        threshold_sell, threshold_buy = -threshold, threshold
     marketcolors = mpf.make_marketcolors(
         up="red",
         down="blue",
@@ -191,9 +195,9 @@ def candle(
         buy_indices = []
         sell_indices = []
         for idx, pos in enumerate(signals["signals"]):
-            if pos >= threshold:
+            if pos >= threshold_buy:
                 buy_indices.append(idx)
-            elif pos <= -threshold:
+            elif pos <= threshold_sell:
                 sell_indices.append(idx)
         for i in buy_indices:
             new_axis.axvline(

--- a/zerohertzLib/plot/plot.py
+++ b/zerohertzLib/plot/plot.py
@@ -138,7 +138,7 @@ def candle(
         >>> title, data = broker.response2ohlcv(apple)
         >>> zz.plot.candle(data, title)
 
-        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/288058335-818715ff-b9d1-45d2-ab3d-328997558d5e.png
+        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/289050270-de857e2a-1dfb-4d14-b4d6-3d4082792275.png
             :alt: Visualzation Result
             :align: center
             :width: 800px

--- a/zerohertzLib/quant/backtest.py
+++ b/zerohertzLib/quant/backtest.py
@@ -37,15 +37,17 @@ def backtest(
     data: Union[pd.core.frame.DataFrame, List[pd.core.frame.DataFrame]],
     signals: Union[pd.core.frame.DataFrame, List[pd.core.frame.DataFrame]],
     ohlc: Optional[str] = "",
-    threshold: Optional[int] = 1,
+    threshold: Optional[Union[int, Tuple[int]]] = 1,
+    signal_key: Optional[str] = "signals",
 ) -> Dict[str, Any]:
     """전략에 의해 생성된 ``signals`` backtest
 
     Args:
         data (``Union[pd.core.frame.DataFrame, List[pd.core.frame.DataFrame]]``): OHLCV (Open, High, Low, Close, Volume) data
-        signals (``Union[pd.core.frame.DataFrame, List[pd.core.frame.DataFrame]]``): ``"signals"`` column이 포함된 data
+        signals (``Union[pd.core.frame.DataFrame, List[pd.core.frame.DataFrame]]``): ``"signals"`` column이 포함된 data (다른 이름으로 지정했을 시 ``signal_key`` 사용)
         ohlc (``Optional[str]``): 사용할 ``data`` 의 column 이름
-        threshold (``Optional[int]``): 매수, 매도를 결정할 ``signals`` 경계값
+        threshold (``Optional[Union[int, Tuple[int]]]``): 매수, 매도를 결정할 ``signals`` 경계값
+        signal_key (``Optional[str]``): ``"signals"`` 의 key 값
 
     Returns:
         ``Dict[str, Any]``: 수익률 (단위: %), 손실 거래 비율 (단위: %), 손실 거래 비율에 따른 수익률, 거래 내역
@@ -62,13 +64,17 @@ def backtest(
             for key, value in result.items():
                 results[key].append(value)
         return results
+    if not isinstance(threshold, int):
+        threshold_sell, threshold_buy = threshold
+    else:
+        threshold_sell, threshold_buy = -threshold, threshold
     wallet_buy = 0
     wallet_sell = 0
     stock = deque()
     transactions = defaultdict(list)
     for idx in data.index:
-        position = signals.loc[idx, "signals"]
-        if position >= threshold:
+        position = signals.loc[idx, signal_key]
+        if position >= threshold_buy:
             if ohlc == "":
                 price = data.loc[idx][:4].mean()
             else:
@@ -76,26 +82,23 @@ def backtest(
             stock.append(price)
             transactions["price"].append(price)
             wallet_buy += price
-        elif position <= -threshold:
+        elif position <= threshold_sell:
             if ohlc == "":
                 price = data.loc[idx][:4].mean()
             else:
                 price = data.loc[idx, ohlc]
             while stock:
-                price_buy = stock.pop()
+                price_buy = stock.popleft()
                 transactions["price"].append(-price)
                 transactions["profit"].append((price - price_buy) / price * 100)
                 wallet_sell += price
     while stock:
         price_buy = stock.pop()
-        if ohlc == "":
-            price = data.iloc[:, :4].mean(1)[-1]
-        else:
-            price = data[ohlc][-1]
-        transactions["price"].append(price)
-        transactions["profit"].append((price - price_buy) / price * 100)
-        wallet_sell += price
-    if wallet_buy == 0:
+        transactions["price"].pop()
+        wallet_buy -= price_buy
+    transactions["buy"] = wallet_buy
+    transactions["sell"] = wallet_sell
+    if wallet_buy == 0 or len(transactions["profit"]) == 0:
         return {
             "profit": -100,
             "loss": 100,
@@ -149,7 +152,7 @@ def experiments(
     Examples:
         Single:
 
-        >>> exps = [[10, 20, 30], [50, 60, 70]]
+        >>> exps = [[10, 20, 25, 30], [70, 75, 80, 85, 90], [14, 21, 31]]
         >>> zz.quant.experiments(title, data, zz.quant.moving_average, exps, report=True)
         10-50:  15.47%  20.00%
         ...
@@ -274,7 +277,7 @@ class Experiments:
             [50, 100, 150, 200],
         ]
         self.exps_rsi = [[10, 20, 25, 30], [70, 75, 80, 85, 90], [14, 21, 31]]
-        self.exps_bollinger_bands = [[20, 30, 40], [1.9, 1.95, 2]]
+        self.exps_bollinger_bands = [[20, 30, 40], [1.9, 1.95, 2, 2.05, 2.1]]
         self.exps_momentum = [[5, 10, 15], [5, 10, 15], [10, 25, 50, 75]]
 
     def _experiments(

--- a/zerohertzLib/quant/backtest.py
+++ b/zerohertzLib/quant/backtest.py
@@ -266,8 +266,8 @@ class Experiments:
             [60, 65, 70, 75, 80],
             [50, 100, 150, 200],
         ]
-        self.exps_rsi = [[10, 20, 30, 40, 50], [70, 75, 80, 85, 90], [7, 14, 31]]
-        self.exps_bollinger_bands = [[10, 14, 21, 30], [1.9, 1.95, 2]]
+        self.exps_rsi = [[10, 20, 25, 30], [70, 75, 80, 85, 90], [14, 21, 31]]
+        self.exps_bollinger_bands = [[20, 30, 40], [1.9, 1.95, 2]]
         self.exps_momentum = [[5, 10, 15], [5, 10, 15], [10, 25, 50, 75]]
 
     def _experiments(

--- a/zerohertzLib/quant/quant.py
+++ b/zerohertzLib/quant/quant.py
@@ -23,10 +23,12 @@ SOFTWARE.
 """
 import multiprocessing as mp
 from collections import defaultdict
+from itertools import combinations
 from typing import Any, Dict, ItemsView, List, Optional, Tuple, Union
 
 import FinanceDataReader as fdr
 import pandas as pd
+import requests
 from matplotlib import pyplot as plt
 
 from zerohertzLib.api import KoreaInvestment, SlackBot
@@ -46,18 +48,33 @@ class Quant(Experiments):
         methods (``Optional[List[str]]``): 사용할 전략들의 함수명
 
     Attributes:
-        backtest (``List[Tuple[Any]]``): 융합된 전략의 backtest 결과
-        params (`Dict[str, List[str]]`): 각 전략에 따른 paramter 문자역
+        signals (``pd.core.frame.DataFrame``): 융합된 전략의 signal
+        params (`Dict[str, List[str]]`): 각 전략에 따른 paramter 문자열
+        cnt (``Dict[str, int]``): 각 전략에 따른 수
         exps (``Dict[str, List[Dict[str, int]]]``): 각 전략에 따른 parameter 분포
+        profit (``float``): 융합된 전략의 backtest profit
+        threshold_buy (``int``): 융합된 전략의 매수 signal threshold
+        threshold_sell (``int``): 융합된 전략의 매도 signal threshold
+        methods (``Tuple[str]``): 융합된 전략명
 
     Examples:
         >>> qnt = zz.quant.Quant(title, data, top=3)
-        >>> qnt.backtest[0]
-        (5.692595336450012, 4, 33.33333333333333, defaultdict(<class 'list'>, {'price': [2385.95, -2521.7725], 'profit': [5.385993383622044]}))
+        >>> qnt.signals.columns
+        Index(['moving_average', 'rsi', 'bollinger_bands', 'momentum', 'signals'], dtype='object')
         >>> qnt.params
-        defaultdict(<class 'list'>, {'moving_average': ['5-75-50', '5-80-50', '5-65-50'], ...})
+        defaultdict(<class 'list'>, {'moving_average': ['10-80-150', '10-80-100', '10-80-200'], ...})
+        >>> qnt.cnt
+        defaultdict(<class 'int'>, {'moving_average': 3, 'rsi': 3, 'bollinger_bands': 3, 'momentum': 3})
         >>> qnt.exps
-        defaultdict(None, {'moving_average': [defaultdict(<class 'int'>, {'5': 3}), defaultdict(<class 'int'>, {'75': 1, '80': 1, '65': 1}), ...], ...})
+        defaultdict(None, {'moving_average': [defaultdict(<class 'int'>, {'10': 3}), defaultdict(<class 'int'>, {'80': 3}), ...]})
+        >>> qnt.profit
+        409.6687719932959
+        >>> qnt.threshold_buy
+        4
+        >>> qnt.threshold_sell
+        -6
+        >>> qnt.methods
+        ('rsi', 'bollinger_bands', 'momentum')
     """
 
     def __init__(
@@ -68,13 +85,11 @@ class Quant(Experiments):
         top: Optional[int] = 1,
         methods: Optional[List[str]] = None,
     ) -> None:
-        super().__init__(title, data, ohlc, False, False)
-        self.data = data
+        super().__init__(title, data, ohlc, False, True)
         self.signals = pd.DataFrame(index=data.index)
         self.params = defaultdict(list)
-        self.exps = defaultdict()
         self.cnt = defaultdict(int)
-        self.cnt_total = 0
+        self.exps = defaultdict()
         if methods is None:
             methods = [
                 "moving_average",
@@ -82,6 +97,8 @@ class Quant(Experiments):
                 "bollinger_bands",
                 "momentum",
             ]
+        # 선정한 전략들의 parameter 최적화
+        cnt_total = 0
         for method in methods:
             if hasattr(self, method):
                 self.signals[method] = 0
@@ -96,57 +113,86 @@ class Quant(Experiments):
                         for i, ex in enumerate(exp):
                             exps_cnt[i][str(ex)] += 1
                         self.cnt[method] += 1
-                        self.cnt_total += 1
+                        cnt_total += 1
                 self.exps[method] = exps_cnt
             else:
                 raise AttributeError(f"'Quant' object has no attribute '{method}'")
-        if self.cnt_total >= 1:
-            self.cnt["total"] = self.cnt_total
-            self.signals["signals"] = self.signals.sum(1)
-            self.backtest = []
-            for threshold in range(1, self.cnt_total + 1):
-                results = backtest(self.data, self.signals, threshold=threshold)
-                self.backtest.append(
-                    (
-                        results["profit"],
-                        threshold,
-                        threshold / self.cnt_total * 100,
-                        results["transaction"],
-                    )
-                )
-            self.backtest.sort(key=lambda x: x[0], reverse=True)
-            self.threshold_abs = self.backtest[0][1]
-            self.threshold_rel = self.backtest[0][2]
+        # 전략 간 조합 최적화
+        if cnt_total >= 1:
+            backtests = []
+            for cnt in range(1, len(methods)):
+                for methods_in_use in combinations(methods, cnt):
+                    miu_total = 0
+                    for miu in methods_in_use:
+                        miu_total += self.cnt[miu]
+                        if self.cnt[miu] < 1:
+                            miu_total = 0
+                            break
+                    if miu_total == 0:
+                        continue
+                    self.signals["signals"] = self.signals.loc[:, methods_in_use].sum(1)
+                    for threshold_sell in range(1, miu_total + 1):
+                        for threshold_buy in range(1, miu_total + 1):
+                            results = backtest(
+                                self.data,
+                                self.signals,
+                                threshold=(-threshold_sell, threshold_buy),
+                            )
+                            backtests.append(
+                                {
+                                    "profit": results["profit"],
+                                    "weighted_profit": results["weighted_profit"],
+                                    "threshold": (-threshold_sell, threshold_buy),
+                                    "methods": methods_in_use,
+                                    "total": miu_total,
+                                    "transaction": results["transaction"],
+                                }
+                            )
+            backtests.sort(key=lambda x: x["weighted_profit"], reverse=True)
+            # 최적 융합 전략
+            self.profit = backtests[0]["profit"]
+            self.threshold_sell, self.threshold_buy = backtests[0]["threshold"]
+            self.methods = backtests[0]["methods"]
+            self.signals["signals"] = self.signals.loc[:, backtests[0]["methods"]].sum(
+                1
+            )
+            self.cnt_total = backtests[0]["total"]
+            self.transaction = backtests[0]["transaction"]
 
-    def run(self, day: Optional[str] = -1) -> Dict[str, Any]:
+    def run(self, day: Optional[str] = -1) -> Dict[str, list]:
         """입력된 날짜에 대해 분석 정보 return
 
         Args:
             day (``Optional[str]``): 분석할 날짜
 
         Returns:
-            ``Dict[str, Any]``: 각 전략에 따른 분석 정보 및 결론
+            ``Dict[str, float]``: 각 전략에 따른 분석 정보 및 결론
 
         Examples:
             >>> qnt.run()
-            defaultdict(<class 'float'>, {'moving_average': 0.0, 'rsi': 0.0, 'bollinger_bands': 0.0, 'momentum': 0.0, 'total': 0.0, 'position': 'None'})
-            >>> qnt.run("20231023")
-            defaultdict(<class 'float'>, {'moving_average': -100.0, 'rsi': 0.0, 'bollinger_bands': 66.66666666666666, 'momentum': 0.0, 'total': -8.333333333333332, 'position': 'None'})
-            >>> qnt.run("2023-04-21")
-            defaultdict(<class 'float'>, {'moving_average': 100.0, 'rsi': 0.0, 'bollinger_bands': 0.0, 'momentum': 33.33333333333333, 'total': 33.33333333333333, 'position': 'Buy'})
+            defaultdict(<class 'list'>, {'rsi': [0, 0.0], 'bollinger_bands': [0, 0.0], 'momentum': [3.0, 100.0], 'total': [3.0, 33.33333333333333], 'position': 'None'})
+            >>> qnt.run("20180425")
+            defaultdict(<class 'list'>, {'rsi': [0, 0.0], 'bollinger_bands': [2, 66.66666666666666], 'momentum': [2.0, 66.66666666666666], 'total': [4.0, 44.44444444444444], 'position': 'Buy'})
+            >>> qnt.run("1998-10-23")
+            defaultdict(<class 'list'>, {'rsi': [0, 0.0], 'bollinger_bands': [0, 0.0], 'momentum': [0.0, 0.0], 'total': [0.0, 0.0], 'position': 'None'})
         """
         if self.cnt_total < 1:
             return {"position": "NULL"}
         if day != -1 and "-" not in day:
             day = day[:4] + "-" + day[4:6] + "-" + day[6:8]
-        possibility = defaultdict(float)
-        for key, value in self.cnt.items():
-            if key != "total" and value != 0:
-                possibility[key] = self.signals[key][day] / value * 100
-        possibility["total"] = self.signals["signals"][day] / self.cnt_total * 100
-        if self.threshold_rel <= possibility["total"]:
+        possibility = defaultdict(list)
+        for key in self.methods:
+            possibility[key] = [
+                self.signals[key][day],
+                self.signals[key][day] / self.cnt[key] * 100,
+            ]
+        possibility["total"] = [
+            self.signals["signals"][day],
+            self.signals["signals"][day] / self.cnt_total * 100,
+        ]
+        if self.threshold_buy <= possibility["total"][0]:
             possibility["position"] = "Buy"
-        elif self.threshold_rel <= -possibility["total"]:
+        elif self.threshold_sell >= -possibility["total"][0]:
             possibility["position"] = "Sell"
         else:
             possibility["position"] = "None"
@@ -365,14 +411,15 @@ class QuantSlackBot(SlackBot):
 
     Args:
         symbols (``List[str]``): 종목 code들
-        token (``str``): Slack Bot의 token
-        channel (``str``): Slack Bot이 전송할 channel
+        token (``Optional[str]``): Slack Bot의 token
+        channel (``Optional[str]``): Slack Bot이 전송할 channel
         start_day (``Optional[str]``): 조회 시작 일자 (``YYYYMMDD``)
         top (``Optional[int]``): Experiments 과정에서 사용할 각 전략별 수
         name (``Optional[str]``): Slack Bot의 표시될 이름
         icon_emoji (``Optional[str]``): Slack Bot의 표시될 사진 (emoji)
         mp_num (``Optional[int]``): 병렬 처리에 사용될 process의 수 (``0``: 직렬 처리)
         analysis (``Optional[bool]``): 각 전략의 보고서 전송 여부
+        kor (``Optional[bool]``): 국내 여부
 
     Attributes:
         exps (``Dict[str, List[Dict[str, int]]]``): 각 전략에 따른 parameter 분포
@@ -381,12 +428,7 @@ class QuantSlackBot(SlackBot):
         >>> qsb = zz.quant.QuantSlackBot(symbols, token, channel)
         >>> qsb.index()
 
-        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/288455654-53146aff-bf04-411e-a932-954e90c81d97.png
-            :alt: Slack Bot Result
-            :align: center
-            :width: 400px
-
-        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/288455675-90300812-c23f-4222-a18f-0c621b03a633.png
+        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/289048168-9c339478-4d61-4ac6-9ecd-e0b9433af264.png
             :alt: Slack Bot Result
             :align: center
             :width: 400px
@@ -395,15 +437,21 @@ class QuantSlackBot(SlackBot):
     def __init__(
         self,
         symbols: List[str],
-        token: str,
-        channel: str,
+        token: Optional[str] = None,
+        channel: Optional[str] = None,
         start_day: Optional[str] = "",
         top: Optional[int] = 1,
         name: Optional[str] = None,
         icon_emoji: Optional[str] = None,
         mp_num: Optional[int] = 0,
         analysis: Optional[bool] = False,
+        kor: Optional[bool] = True,
     ) -> None:
+        if token is None or channel is None:
+            self.slack = False
+            token = ""
+        else:
+            self.slack = True
         SlackBot.__init__(self, token, channel, name, icon_emoji)
         self.symbols = symbols
         self.start_day = start_day
@@ -413,11 +461,30 @@ class QuantSlackBot(SlackBot):
         else:
             self.mp_num = mp_num
         self.analysis = analysis
+        self.kor = kor
+
+    def message(
+        self,
+        message: str,
+        codeblock: Optional[bool] = False,
+    ) -> requests.models.Response:
+        """``token`` 혹은 ``channel`` 이 입력되지 않을 시 전송 불가"""
+        if self.slack:
+            return super().message(message, codeblock)
+        return None
+
+    def file(self, path: str) -> requests.models.Response:
+        """``token`` 혹은 ``channel`` 이 입력되지 않을 시 전송 불가"""
+        if self.slack:
+            return super().file(path)
+        return None
 
     def _cash2str(self, cash: str) -> str:
-        return f"{cash:,.0f}원"
+        if self.kor:
+            return f"{cash:,.0f}원"
+        return f"${cash:,.2f}"
 
-    def _report(self, name: str, quant: Quant, today: Dict[str, Any]):
+    def _report(self, name: str, quant: Quant, today: Dict[str, float]):
         report = ""
         if today["position"] == "Buy":
             report += f"> :chart_with_upwards_trend: [Buy Signal] *{name}*\n"
@@ -425,23 +492,24 @@ class QuantSlackBot(SlackBot):
             report += f"> :chart_with_downwards_trend: [Sell Signal] *{name}*\n"
         else:
             report += f"> :egg: [None Signal] *{name}*\n"
-        for key, value in today.items():
-            if key != "position":
-                if key == "total":
-                    report += f":heavy_dollar_sign: {key.replace('_', ' ').upper()}:\t{value:.2f}%\t({quant.cnt[key]})\n"
-                else:
-                    report += f":heavy_dollar_sign: {key.replace('_', ' ').upper()}:\t{value:.2f}%\t(`{'`, `'.join(quant.params[key])}`)\n"
-        report += f":heavy_dollar_sign: THRESHOLD: `{quant.threshold_abs}`, `{quant.threshold_rel:.1f}%`\n"
-        report += f"*Backtest*\n:white_check_mark: Total Profit:\t{quant.backtest[0][0]:.2f}%\n"
+        report += f"\t:heavy_dollar_sign: SIGNAL's INFO: {today['total'][1]:.2f}% (`{today['total'][0]}/{quant.cnt_total}`)\n"
+        for key in quant.methods:
+            report += f"\t:hammer: {key.replace('_', ' ').upper()}:\t{today[key][1]:.2f}%\t(`{today[key][0]}/{quant.cnt[key]}`)\t"
+            report += f"`{'`, `'.join(quant.params[key])}`\n"
+        report += f"\t:memo: THRESHOLD:\n"
+        report += f"\t\t:arrow_double_up: BUY: `{quant.threshold_buy}`\n\t\t:arrow_double_down: SELL: `{quant.threshold_sell}`\n"
+        report += (
+            f"*Backtest*\n\t:money_with_wings: Total Profit:\t{quant.profit:.2f}%\n"
+        )
+        report += f"\t:chart_with_upwards_trend: Total Buy:\t{self._cash2str(quant.transaction['buy'])}\n"
+        report += f"\t:chart_with_downwards_trend: Total Sell:\t{self._cash2str(quant.transaction['sell'])}\n"
         transaction_price = [
-            self._cash2str(price) for price in quant.backtest[0][3]["price"]
+            self._cash2str(price) for price in quant.transaction["price"]
         ]
-        transaction_profit = [
-            f"{price:.2f}%" for price in quant.backtest[0][3]["profit"]
-        ]
+        transaction_profit = [f"{price:.2f}%" for price in quant.transaction["profit"]]
         transaction_price = "```" + " -> ".join(transaction_price) + "```"
         transaction_profit = "```" + " -> ".join(transaction_profit) + "```"
-        report += f":white_check_mark: Transactions:\n{transaction_price}\n{transaction_profit}"
+        report += f"\t:bank: Transactions:\n{transaction_price}\n{transaction_profit}"
         return report
 
     def _get_data(self, symbol: str) -> Tuple[str, pd.core.frame.DataFrame]:
@@ -471,9 +539,11 @@ class QuantSlackBot(SlackBot):
             path = candle(
                 quant.data[-500:],
                 quant.title,
-                signals=quant.signals.iloc[-500:, :].loc[:, ["signals"]],
+                signals=quant.signals.iloc[-500:, :].loc[
+                    :, [*quant.methods, "signals"]
+                ],
                 dpi=100,
-                threshold=quant.threshold_abs,
+                threshold=(quant.threshold_sell, quant.threshold_buy),
             )
             return self._report(title, quant, today), path, quant.exps
         return None, None, quant.exps
@@ -556,9 +626,9 @@ class QuantSlackBotKI(Balance, QuantSlackBot):
     """한국투자증권 API를 기반으로 입력된 여러 종목에 대해 매수, 매도 signal을 판단하고 Slack으로 message와 graph를 전송하는 class
 
     Args:
-        symbols (``List[str]``): 종목 code들
-        token (``str``): Slack Bot의 token
-        channel (``str``): Slack Bot이 전송할 channel
+        symbols (``Optional[List[str]]``): 종목 code들
+        token (``Optional[str]``): Slack Bot의 token
+        channel (``Optional[str]``): Slack Bot이 전송할 channel
         path (``Optional[str]``): ``secret.key`` 혹은 ``token.dat`` 이 포함된 경로
         start_day (``Optional[str]``): 조회 시작 일자 (``YYYYMMDD``)
         top (``Optional[int]``): Experiments 과정에서 사용할 각 전략별 수
@@ -566,6 +636,7 @@ class QuantSlackBotKI(Balance, QuantSlackBot):
         icon_emoji (``Optional[str]``): Slack Bot의 표시될 사진 (emoji)
         mp_num (``Optional[int]``): 병렬 처리에 사용될 process의 수 (``0``: 직렬 처리)
         analysis (``Optional[bool]``): 각 전략의 보고서 전송 여부
+        kor (``Optional[bool]``): 국내 여부
 
     Attributes:
         exps (``Dict[str, List[Dict[str, int]]]``): 각 전략에 따른 parameter 분포
@@ -576,9 +647,9 @@ class QuantSlackBotKI(Balance, QuantSlackBot):
 
     def __init__(
         self,
-        symbols: List[str],
-        token: str,
-        channel: str,
+        symbols: Optional[List[str]] = None,
+        token: Optional[str] = None,
+        channel: Optional[str] = None,
         path: Optional[str] = "./",
         start_day: Optional[str] = "",
         top: Optional[int] = 1,
@@ -586,8 +657,11 @@ class QuantSlackBotKI(Balance, QuantSlackBot):
         icon_emoji: Optional[str] = None,
         mp_num: Optional[int] = 0,
         analysis: Optional[bool] = False,
+        kor: Optional[bool] = True,
     ) -> None:
-        Balance.__init__(self, path)
+        Balance.__init__(self, path, kor)
+        if symbols is None:
+            symbols = []
         QuantSlackBot.__init__(
             self,
             symbols,
@@ -599,6 +673,7 @@ class QuantSlackBotKI(Balance, QuantSlackBot):
             icon_emoji,
             mp_num,
             analysis,
+            kor,
         )
         symbols_bought = self.bought_symbols()
         for symbol in symbols_bought:
@@ -608,7 +683,7 @@ class QuantSlackBotKI(Balance, QuantSlackBot):
         self.symbols_bought = symbols_bought
 
     def _get_data(self, symbol: str) -> Tuple[str, pd.core.frame.DataFrame]:
-        response = self.get_ohlcv(symbol, start_day=self.start_day)
+        response = self.get_ohlcv(symbol, start_day=self.start_day, kor=self.kor)
         title, data = self.response2ohlcv(response)
         return title, data
 
@@ -635,8 +710,8 @@ class QuantSlackBotFDR(QuantSlackBot):
 
     Args:
         symbols (``Union[int, List[str]]``): 종목 code들 혹은 시가 총액 순위
-        token (``str``): Slack Bot의 token
-        channel (``str``): Slack Bot이 전송할 channel
+        token: Optional[str] = None,
+        channel: Optional[str] = None,
         start_day (``Optional[str]``): 조회 시작 일자 (``YYYYMMDD``)
         top (``Optional[int]``): Experiments 과정에서 사용할 각 전략별 수
         name (``Optional[str]``): Slack Bot의 표시될 이름
@@ -657,8 +732,8 @@ class QuantSlackBotFDR(QuantSlackBot):
     def __init__(
         self,
         symbols: Union[int, List[str]],
-        token: str,
-        channel: str,
+        token: Optional[str] = None,
+        channel: Optional[str] = None,
         start_day: Optional[str] = "",
         top: Optional[int] = 1,
         name: Optional[str] = None,
@@ -678,8 +753,8 @@ class QuantSlackBotFDR(QuantSlackBot):
             icon_emoji,
             mp_num,
             analysis,
+            kor,
         )
-        self.kor = kor
         if kor:
             self.market = fdr.StockListing("KRX")
             self.market = self.market.sort_values("Marcap", ascending=False)

--- a/zerohertzLib/quant/quant.py
+++ b/zerohertzLib/quant/quant.py
@@ -682,6 +682,7 @@ class QuantSlackBotFDR(QuantSlackBot):
         self.kor = kor
         if kor:
             self.market = fdr.StockListing("KRX")
+            self.market = self.market.sort_values("Marcap", ascending=False)
         else:
             self.market = fdr.StockListing("NASDAQ")
         if isinstance(symbols, int):

--- a/zerohertzLib/quant/quant.py
+++ b/zerohertzLib/quant/quant.py
@@ -496,7 +496,7 @@ class QuantSlackBot(SlackBot):
         for key in quant.methods:
             report += f"\t:hammer: {key.replace('_', ' ').upper()}:\t{today[key][1]:.2f}%\t(`{today[key][0]}/{quant.cnt[key]}`)\t"
             report += f"`{'`, `'.join(quant.params[key])}`\n"
-        report += f"\t:memo: THRESHOLD:\n"
+        report += "\t:memo: THRESHOLD:\n"
         report += f"\t\t:arrow_double_up: BUY: `{quant.threshold_buy}`\n\t\t:arrow_double_down: SELL: `{quant.threshold_sell}`\n"
         report += (
             f"*Backtest*\n\t:money_with_wings: Total Profit:\t{quant.profit:.2f}%\n"

--- a/zerohertzLib/quant/strategies.py
+++ b/zerohertzLib/quant/strategies.py
@@ -65,7 +65,7 @@ def moving_average(
         2023-12-05    72255.00   69838.50      1.0
         [248 rows x 3 columns]
 
-        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/288449614-5c3ab869-5a6b-4a1c-bb7e-8c93cdb434c8.png
+        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/289050247-8407baa6-abb9-490a-abc6-37500a05ff22.png
             :alt: Visualzation Result
             :align: center
             :width: 600px
@@ -150,7 +150,7 @@ def rsi(
         2023-12-05  58.563536        0
         [248 rows x 2 columns]
 
-        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/288449622-ab75b83b-dc0c-4f69-a7b1-763c5287398e.png
+        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/289050264-6993d6ac-de6b-47f8-9657-897e5e66d2fd.png
             :alt: Visualzation Result
             :align: center
             :width: 600px
@@ -277,7 +277,7 @@ def momentum(
         2023-12-05     190.0      0.0
         [248 rows x 2 columns]
 
-        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/288449598-1eae1885-61cb-46c5-8af9-4936a1ca7b83.png
+        .. image:: https://github-production-user-asset-6210df.s3.amazonaws.com/42334717/289050257-64e5b1d5-7518-4161-9d40-777f6201cd6b.png
             :alt: Visualzation Result
             :align: center
             :width: 600px

--- a/zerohertzLib/quant/strategies.py
+++ b/zerohertzLib/quant/strategies.py
@@ -92,13 +92,18 @@ def moving_average(
         )
     gap = data.iloc[:, :4].mean().mean() / gap
     signals["signals"] = 0.0
+    prev = 0
     for i in range(len(signals)):
         short = signals["short_mavg"].iloc[i]
         long = signals["long_mavg"].iloc[i]
         if short > long + gap:
-            signals.loc[signals.index[i], "signals"] = 1
+            if prev == -1:
+                signals.loc[signals.index[i], "signals"] = 1
+            prev = 1
         elif short + gap < long:
-            signals.loc[signals.index[i], "signals"] = -1
+            if prev == 1:
+                signals.loc[signals.index[i], "signals"] = -1
+            prev = -1
     return signals
 
 


### PR DESCRIPTION
### Features

+ `api`
  `KoreaInvestment._get_korea_ohlcv` 및 `KoreaInvestment._get_oversea_ohlcv`의 API 반복 호출 error 수정
+ `plot`
  + Candle chart의 `threshold`를 매수, 매도에 나눠 plot 할 수 있도록 update
+ `quant`
  + `SlackBot`와 `Balance`의 국외 주식 지원 update
  + `backtest` 방법론 refactoring
  + `Quant` class의 전략 최적화 시 매수, 매도의 `threshold`를 별도로 산정하도록 변경
